### PR TITLE
add mpesa ratiba request for standing orders

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -8,9 +8,9 @@ import (
 
 const (
 	// Set environment variables for daraja before testing. Here I am using sandbox settings-.
-	mpesaPassKey        = "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
-	mpesaApiKey         = "YCWLzwRKndyK7Il3NbyshtxJHZ9aYjTGEkjwdj0NpET46kAo"
-	mpesaConsumerSecret = "Ar7cNir15oZdA9F5YVr8AMiF57Lb7errEmtR10OdRwrAXudTDAWDB0Aa12hGI5bR"
+	mpesaPassKey        = "mpesa key value"
+	mpesaApiKey         = "api key value"
+	mpesaConsumerSecret = "secret value"
 )
 
 func main() {

--- a/examples/main.go
+++ b/examples/main.go
@@ -8,15 +8,15 @@ import (
 
 const (
 	// Set environment variables for daraja before testing. Here I am using sandbox settings-.
-	mpesaPassKey        = "mpesa key value"
-	mpesaApiKey         = "api key value"
-	mpesaConsumerSecret = "secret value"
+	mpesaPassKey        = "bfb279f9aa9bdbcf158e97dd71a467cd2e0c893059b10f78e6b72ada1ed2c919"
+	mpesaApiKey         = "YCWLzwRKndyK7Il3NbyshtxJHZ9aYjTGEkjwdj0NpET46kAo"
+	mpesaConsumerSecret = "Ar7cNir15oZdA9F5YVr8AMiF57Lb7errEmtR10OdRwrAXudTDAWDB0Aa12hGI5bR"
 )
 
 func main() {
 	// Initialize daraja service. PassKey is provided on your portal for sandbox,
 	// while it is shared on your go live email from apisupport@safaricom.co.ke
-	darajaService, err := daraja.New(mpesaApiKey, mpesaConsumerSecret, mpesaPassKey, daraja.PRODUCTION)
+	darajaService, err := daraja.New(mpesaApiKey, mpesaConsumerSecret, mpesaPassKey, daraja.SANDBOX)
 
 	if err != nil {
 		log.Println("failed initializing safaricom daraja client ", err)
@@ -31,6 +31,14 @@ func main() {
 
 	log.Println("Daraja Token ", token)
 
+	mpesaRatiba, err := initiateMpesaRatiba(darajaService)
+
+	if err != nil {
+		log.Println("Error initiate mpesa ratiba standing order ", err.Error())
+	}
+
+	log.Printf("MRATIBA response is %+v \n", mpesaRatiba)
+
 	// Implements registering a confirmation and validation url.If response code is zero then it passed -.
 	confirmationResponseCode, err := registerConfirmationUrl(darajaService)
 
@@ -40,7 +48,7 @@ func main() {
 
 	log.Println("Register URL response code ", confirmationResponseCode)
 
-	//Implements stk push service -.
+	// Implements stk push service -.
 	stkRes, err := initiateStkPush(darajaService)
 
 	if err != nil {
@@ -116,6 +124,33 @@ func main() {
 
 	log.Printf("B2C response %+v \n", b2cRes)
 
+}
+
+// Request customer to approve mpesa ratiba standing order for given details in the request for reoccurring payments -.
+func initiateMpesaRatiba(darajaService *daraja.DarajaService) (*daraja.MpesaRatibaRequestResponseBody, error) {
+
+	ratibaResponse, err := darajaService.InitiateMpesaRatibaRequest(daraja.MpesaRatibaRequestBody{
+		StandingOrderName: "Test standing order",
+		// This should be from an enum type for values 2 for Till or 4 for Pay Bill-.
+		ReceiverPartyIdentifierType: daraja.ReceiverPartyBusinessShortCode,
+		// This should be from an enum type Standing Order Customer Pay Bill and Standing Order Customer Pay Merchant -.
+		TransactionType:   daraja.TransactionTypePayBill,
+		BusinessShortCode: "174379",
+		PartyA:            "254728922267",
+		Amount:            "1",
+		StartDate:         "20250206",
+		EndDate:           "20250207",
+		Frequency:         "2",
+		AccountReference:  "Test mpesa ratiba",
+		TransactionDesc:   "Test",
+		CallBackURL:       "https://webhook.site/7732c802-1c21-4b42-8f22-fc1873a07c82",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ratibaResponse, nil
 }
 
 // checking account balance for both B2C and C2B short codes -.
@@ -235,13 +270,13 @@ func businessPayBillPayment(darajaService *daraja.DarajaService) (*daraja.Busine
 func initiateStkPush(darajaService *daraja.DarajaService) (*daraja.StkPushResponse, error) {
 	// "CustomerPayBillOnline" for PayBill Numbers and "CustomerBuyGoodsOnline" for Till Numbers.
 	stkRes, err := darajaService.InitiateStkPush(daraja.STKPushBody{
-		BusinessShortCode: "7675771",
-		TransactionType:   "CustomerBuyGoodsOnline",
+		BusinessShortCode: "174379",
+		TransactionType:   "CustomerPayBillOnline",
 		Amount:            "1",
 		PartyA:            "254728922267",
-		PartyB:            "5706975",
+		PartyB:            "174379",
 		PhoneNumber:       "254728922267",
-		CallBackURL:       "https://webhook.site/bbca16b1-fc3b-4a9f-9a91-14c08972657e",
+		CallBackURL:       "https://webhook.site/7732c802-1c21-4b42-8f22-fc1873a07c82",
 		AccountReference:  "999200200",
 		TransactionDesc:   "Daraja sdk testing STK push",
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/harmannkibue/golang-mpesa-sdk
 go 1.22.2
 
 require github.com/patrickmn/go-cache v2.1.0+incompatible
-
-require github.com/joho/godotenv v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=

--- a/pkg/daraja/mpesaRatiba.go
+++ b/pkg/daraja/mpesaRatiba.go
@@ -1,0 +1,102 @@
+package daraja
+
+import (
+	"encoding/json"
+	"github.com/harmannkibue/golang-mpesa-sdk/internal/utils/httprequest"
+)
+
+type ReceiverPartyIdentifierType string
+type TransactionType string
+
+const (
+	ReceiverPartyMerchantTill      ReceiverPartyIdentifierType = "2"
+	ReceiverPartyBusinessShortCode ReceiverPartyIdentifierType = "4"
+)
+
+const (
+	TransactionTypePayBill     TransactionType = "Standing Order Customer Pay Bill"
+	TransactionTypePayMerchant TransactionType = "Standing Order Customer Pay Merchant"
+)
+
+type MpesaRatibaRequestBody struct {
+	StandingOrderName           string                      `json:"StandingOrderName"`
+	ReceiverPartyIdentifierType ReceiverPartyIdentifierType `json:"ReceiverPartyIdentifierType"`
+	TransactionType             TransactionType             `json:"TransactionType"`
+	BusinessShortCode           string                      `json:"BusinessShortCode"`
+	PartyA                      string                      `json:"PartyA"`
+	Amount                      string                      `json:"Amount"`
+	StartDate                   string                      `json:"StartDate"`
+	EndDate                     string                      `json:"EndDate"`
+	Frequency                   string                      `json:"Frequency"`
+	AccountReference            string                      `json:"AccountReference"`
+	TransactionDesc             string                      `json:"TransactionDesc"`
+	CallBackURL                 string                      `json:"CallBackURL"`
+}
+
+type MpesaRatibaRequestResponseBody struct {
+	ResponseHeader struct {
+		ResponseRefID       string `json:"responseRefID"`
+		ResponseCode        string `json:"responseCode"`
+		ResponseDescription string `json:"responseDescription"`
+	} `json:"ResponseHeader"`
+	ResponseBody struct {
+		ResponseDescription string `json:"responseDescription"`
+		ResponseCode        string `json:"responseCode"`
+	} `json:"ResponseBody"`
+}
+
+// InitiateMpesaRatibaRequest Initiate an Mpesa Ratiba standing order to customer -.
+func (s DarajaService) InitiateMpesaRatibaRequest(stkRequest MpesaRatibaRequestBody) (*MpesaRatibaRequestResponseBody, error) {
+
+	body, err := json.Marshal(MpesaRatibaRequestBody{
+		StandingOrderName:           stkRequest.StandingOrderName,
+		ReceiverPartyIdentifierType: stkRequest.ReceiverPartyIdentifierType,
+		BusinessShortCode:           stkRequest.BusinessShortCode,
+		TransactionType:             stkRequest.TransactionType,
+		PartyA:                      stkRequest.PartyA,
+		Amount:                      stkRequest.Amount,
+		StartDate:                   stkRequest.StartDate,
+		EndDate:                     stkRequest.EndDate,
+		Frequency:                   stkRequest.Frequency,
+		AccountReference:            stkRequest.AccountReference,
+		TransactionDesc:             stkRequest.TransactionDesc,
+		CallBackURL:                 stkRequest.CallBackURL,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := s.GetToken()
+
+	if err != nil {
+		return nil, err
+	}
+
+	headers := make(map[string]string)
+	headers["Content-Type"] = "application/json"
+	headers["Authorization"] = "Bearer " + token
+	headers["Cache-Control"] = "no-cache"
+
+	url := s.baseURL() + "standingorder/v1/createStandingOrderExternal"
+
+	response, err := s.HttpRequest.PerformPost(httprequest.RequestDataParams{
+		Endpoint: url,
+		Data:     body,
+		Params:   make(map[string]string),
+	}, BackOffStrategy,
+		headers)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var mRatibaResponse MpesaRatibaRequestResponseBody
+	err = json.NewDecoder(response.Body).Decode(&mRatibaResponse)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &mRatibaResponse, nil
+}


### PR DESCRIPTION
Safaricom's mpesa recently introduced a standing order commercial api for reccurring payments. 
The feature is up pending tests.